### PR TITLE
Use defined gradle_tools variable and update to 3.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply from: 'buildsystem/dependencies.gradle'
 
 buildscript {
   ext.kotlin_version = '1.2.31'
-  ext.gradle_tools = '3.1.0'
+  ext.gradle_tools = '3.1.3'
   ext.build_tools = '27.0.3'
 
   ext.compile_sdk = 27
@@ -21,7 +21,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.3'
+    classpath "com.android.tools.build:gradle:$gradle_tools"
     //noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }


### PR DESCRIPTION
This addresses a minor issue where a gradle_tools version was defined in the top-level Gradle file but was not used. 