### PR TITLE
Update coroutines to 1.0.0 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,9 +112,3 @@ dependencies {
   releaseImplementation developmentDependencies.leakCanaryNoop
   testImplementation developmentDependencies.leakCanaryNoop
 }
-
-kotlin {
-  experimental {
-    coroutines "enable"
-  }
-}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
   def config = rootProject.extensions.getByName("ext")
 
   compileSdkVersion config["compile_sdk"]
-  buildToolsVersion '28.0.3'
+  buildToolsVersion '28.0.2'
 
   defaultConfig {
     applicationId config["application_id"]

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
   def config = rootProject.extensions.getByName("ext")
 
   compileSdkVersion config["compile_sdk"]
-  buildToolsVersion '28.0.2'
+  buildToolsVersion '28.0.3'
 
   defaultConfig {
     applicationId config["application_id"]

--- a/app/src/main/kotlin/com/fernandocejas/sample/core/interactor/UseCase.kt
+++ b/app/src/main/kotlin/com/fernandocejas/sample/core/interactor/UseCase.kt
@@ -34,14 +34,12 @@ abstract class UseCase<out Type, in Params> where Type : Any {
 
     abstract suspend fun run(params: Params): Either<Failure, Type>
 
-    operator fun invoke(params: Params, onResult: (Either<Failure, Type>) -> Unit = {}) {
-        uiScope.launch {
-            val job = async(Dispatchers.IO) { run(params) }
-            onResult(job.await())
-        }
-    }
+    operator fun invoke(params: Params, onResult: (Either<Failure, Type>) -> Unit = {}) =
+            uiScope.launch { onResult(withContext(Dispatchers.IO) { run(params) }) }
 
-    fun cancel() { mainJob.cancel() }
+    fun cancel() {
+        mainJob.cancel()
+    }
 
     class None
 }

--- a/app/src/main/kotlin/com/fernandocejas/sample/core/interactor/UseCase.kt
+++ b/app/src/main/kotlin/com/fernandocejas/sample/core/interactor/UseCase.kt
@@ -17,10 +17,10 @@ package com.fernandocejas.sample.core.interactor
 
 import com.fernandocejas.sample.core.exception.Failure
 import com.fernandocejas.sample.core.functional.Either
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 
 /**
  * Abstract class for a Use Case (Interactor in terms of Clean Architecture).
@@ -35,8 +35,10 @@ abstract class UseCase<out Type, in Params> where Type : Any {
     abstract suspend fun run(params: Params): Either<Failure, Type>
 
     operator fun invoke(params: Params, onResult: (Either<Failure, Type>) -> Unit = {}) {
-        val job = async(CommonPool) { run(params) }
-        launch(UI) { onResult(job.await()) }
+        GlobalScope.launch(Dispatchers.Main) {
+            val job = async(Dispatchers.IO) { run(params) }
+            onResult(job.await())
+        }
     }
 
     class None

--- a/app/src/main/kotlin/com/fernandocejas/sample/core/platform/BaseViewModel.kt
+++ b/app/src/main/kotlin/com/fernandocejas/sample/core/platform/BaseViewModel.kt
@@ -18,17 +18,23 @@ package com.fernandocejas.sample.core.platform
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import com.fernandocejas.sample.core.exception.Failure
+import com.fernandocejas.sample.core.interactor.UseCase
 
 /**
  * Base ViewModel class with default Failure handling.
  * @see ViewModel
  * @see Failure
  */
-abstract class BaseViewModel : ViewModel() {
+abstract class BaseViewModel(private val useCase: UseCase<*, *>) : ViewModel() {
 
     var failure: MutableLiveData<Failure> = MutableLiveData()
 
     protected fun handleFailure(failure: Failure) {
         this.failure.value = failure
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        useCase.cancel()
     }
 }

--- a/app/src/main/kotlin/com/fernandocejas/sample/core/platform/BaseViewModel.kt
+++ b/app/src/main/kotlin/com/fernandocejas/sample/core/platform/BaseViewModel.kt
@@ -18,14 +18,13 @@ package com.fernandocejas.sample.core.platform
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import com.fernandocejas.sample.core.exception.Failure
-import com.fernandocejas.sample.core.interactor.UseCase
 
 /**
  * Base ViewModel class with default Failure handling.
  * @see ViewModel
  * @see Failure
  */
-abstract class BaseViewModel(private val useCase: UseCase<*, *>) : ViewModel() {
+abstract class BaseViewModel : ViewModel() {
 
     var failure: MutableLiveData<Failure> = MutableLiveData()
 
@@ -35,6 +34,8 @@ abstract class BaseViewModel(private val useCase: UseCase<*, *>) : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        useCase.cancel()
+        cancelRequest()
     }
+
+    abstract fun cancelRequest()
 }

--- a/app/src/main/kotlin/com/fernandocejas/sample/features/movies/MovieDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/fernandocejas/sample/features/movies/MovieDetailsViewModel.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 
 class MovieDetailsViewModel
 @Inject constructor(private val getMovieDetails: GetMovieDetails,
-                    private val playMovie: PlayMovie) : BaseViewModel() {
+                    private val playMovie: PlayMovie) : BaseViewModel(getMovieDetails) {
 
     var movieDetails: MutableLiveData<MovieDetailsView> = MutableLiveData()
 

--- a/app/src/main/kotlin/com/fernandocejas/sample/features/movies/MovieDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/fernandocejas/sample/features/movies/MovieDetailsViewModel.kt
@@ -16,14 +16,13 @@
 package com.fernandocejas.sample.features.movies
 
 import android.arch.lifecycle.MutableLiveData
-import com.fernandocejas.sample.features.movies.GetMovieDetails.Params
 import com.fernandocejas.sample.core.platform.BaseViewModel
+import com.fernandocejas.sample.features.movies.GetMovieDetails.Params
 import javax.inject.Inject
 
 class MovieDetailsViewModel
 @Inject constructor(private val getMovieDetails: GetMovieDetails,
-                    private val playMovie: PlayMovie) : BaseViewModel(getMovieDetails) {
-
+                    private val playMovie: PlayMovie) : BaseViewModel() {
     var movieDetails: MutableLiveData<MovieDetailsView> = MutableLiveData()
 
     fun loadMovieDetails(movieId: Int) =
@@ -34,5 +33,10 @@ class MovieDetailsViewModel
     private fun handleMovieDetails(movie: MovieDetails) {
         this.movieDetails.value = MovieDetailsView(movie.id, movie.title, movie.poster,
                 movie.summary, movie.cast, movie.director, movie.year, movie.trailer)
+    }
+
+    override fun cancelRequest() {
+        getMovieDetails.cancel()
+        playMovie.cancel()
     }
 }

--- a/app/src/main/kotlin/com/fernandocejas/sample/features/movies/MoviesViewModel.kt
+++ b/app/src/main/kotlin/com/fernandocejas/sample/features/movies/MoviesViewModel.kt
@@ -21,7 +21,7 @@ import com.fernandocejas.sample.core.platform.BaseViewModel
 import javax.inject.Inject
 
 class MoviesViewModel
-@Inject constructor(private val getMovies: GetMovies) : BaseViewModel() {
+@Inject constructor(private val getMovies: GetMovies) : BaseViewModel(getMovies) {
 
     var movies: MutableLiveData<List<MovieView>> = MutableLiveData()
 

--- a/app/src/main/kotlin/com/fernandocejas/sample/features/movies/MoviesViewModel.kt
+++ b/app/src/main/kotlin/com/fernandocejas/sample/features/movies/MoviesViewModel.kt
@@ -21,13 +21,16 @@ import com.fernandocejas.sample.core.platform.BaseViewModel
 import javax.inject.Inject
 
 class MoviesViewModel
-@Inject constructor(private val getMovies: GetMovies) : BaseViewModel(getMovies) {
-
+@Inject constructor(private val getMovies: GetMovies) : BaseViewModel() {
     var movies: MutableLiveData<List<MovieView>> = MutableLiveData()
 
     fun loadMovies() = getMovies(None()) { it.either(::handleFailure, ::handleMovieList) }
 
     private fun handleMovieList(movies: List<Movie>) {
         this.movies.value = movies.map { MovieView(it.id, it.poster) }
+    }
+
+    override fun cancelRequest() {
+        getMovies.cancel()
     }
 }

--- a/app/src/test/kotlin/com/fernandocejas/sample/core/interactor/UseCaseTest.kt
+++ b/app/src/test/kotlin/com/fernandocejas/sample/core/interactor/UseCaseTest.kt
@@ -19,7 +19,7 @@ import com.fernandocejas.sample.AndroidTest
 import com.fernandocejas.sample.core.exception.Failure
 import com.fernandocejas.sample.core.functional.Either
 import com.fernandocejas.sample.core.functional.Either.Right
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldEqual
 import org.junit.Test
 

--- a/app/src/test/kotlin/com/fernandocejas/sample/core/platform/BaseViewModelTest.kt
+++ b/app/src/test/kotlin/com/fernandocejas/sample/core/platform/BaseViewModelTest.kt
@@ -19,6 +19,8 @@ import android.arch.lifecycle.MutableLiveData
 import com.fernandocejas.sample.AndroidTest
 import com.fernandocejas.sample.core.exception.Failure
 import com.fernandocejas.sample.core.exception.Failure.NetworkConnection
+import com.fernandocejas.sample.core.functional.Either
+import com.fernandocejas.sample.core.interactor.UseCase
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.Test
 
@@ -36,7 +38,13 @@ class BaseViewModelTest : AndroidTest() {
         error shouldBeInstanceOf NetworkConnection::class.java
     }
 
-    private class MyViewModel : BaseViewModel() {
+    private class DummyUseCase : UseCase<Any, Any>() {
+        override suspend fun run(params: Any): Either<Failure, Any> {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+    }
+
+    private class MyViewModel : BaseViewModel(DummyUseCase()) {
         fun handleError(failure: Failure) = handleFailure(failure)
     }
 }

--- a/app/src/test/kotlin/com/fernandocejas/sample/core/platform/BaseViewModelTest.kt
+++ b/app/src/test/kotlin/com/fernandocejas/sample/core/platform/BaseViewModelTest.kt
@@ -44,7 +44,11 @@ class BaseViewModelTest : AndroidTest() {
         }
     }
 
-    private class MyViewModel : BaseViewModel(DummyUseCase()) {
+    private class MyViewModel : BaseViewModel() {
         fun handleError(failure: Failure) = handleFailure(failure)
+
+        override fun cancelRequest() {
+            //Nothing to do
+        }
     }
 }

--- a/app/src/test/kotlin/com/fernandocejas/sample/features/movies/GetMovieDetailsTest.kt
+++ b/app/src/test/kotlin/com/fernandocejas/sample/features/movies/GetMovieDetailsTest.kt
@@ -20,7 +20,7 @@ import com.fernandocejas.sample.core.functional.Either.Right
 import com.nhaarman.mockito_kotlin.given
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock

--- a/app/src/test/kotlin/com/fernandocejas/sample/features/movies/GetMoviesTest.kt
+++ b/app/src/test/kotlin/com/fernandocejas/sample/features/movies/GetMoviesTest.kt
@@ -21,7 +21,7 @@ import com.fernandocejas.sample.core.interactor.UseCase
 import com.nhaarman.mockito_kotlin.given
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock

--- a/app/src/test/kotlin/com/fernandocejas/sample/features/movies/MovieDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/fernandocejas/sample/features/movies/MovieDetailsViewModelTest.kt
@@ -20,7 +20,7 @@ import com.fernandocejas.sample.core.functional.Either.Right
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.given
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldEqualTo
 import org.junit.Before
 import org.junit.Test

--- a/app/src/test/kotlin/com/fernandocejas/sample/features/movies/MoviesViewModelTest.kt
+++ b/app/src/test/kotlin/com/fernandocejas/sample/features/movies/MoviesViewModelTest.kt
@@ -20,7 +20,7 @@ import com.fernandocejas.sample.core.functional.Either.Right
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.given
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldEqualTo
 import org.junit.Before
 import org.junit.Test

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply from: 'buildsystem/ci.gradle'
 apply from: 'buildsystem/dependencies.gradle'
 
 buildscript {
-  ext.kotlin_version = '1.2.51'
+  ext.kotlin_version = '1.3.0'
   ext.gradle_tools = '3.1.3'
   ext.build_tools = '27.0.3'
 
@@ -21,7 +21,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:3.2.0"
+    classpath "com.android.tools.build:gradle:3.2.1"
     //noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply from: 'buildsystem/ci.gradle'
 apply from: 'buildsystem/dependencies.gradle'
 
 buildscript {
-  ext.kotlin_version = '1.3.0'
+  ext.kotlin_version = '1.3.10'
   ext.gradle_tools = '3.1.3'
   ext.build_tools = '27.0.3'
 

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -7,7 +7,7 @@ allprojects {
 
 ext {
   //Android libraries
-  appCompat_version = '27.1.0'
+  appCompat_version = '27.1.1'
   constraintLayout_version = '1.0.2'
   archComponents_version = '1.1.1'
   glide_version = '4.0.0'

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
   glide_version = '4.0.0'
 
   //Third party libraries
-  kotlin_coroutines_version = '0.22.1'
+  kotlin_coroutines_version = '1.0.0'
   dagger_version = '2.11'
   javaxAnnotations_version = '1.0'
   javaxInject_version = '1'


### PR DESCRIPTION
In the version of Kotlin 1.3.0 experimental coroutines are deprecated. Some changes to reimplement with the new syntax have been done.